### PR TITLE
CT-9528 feat: add monthChanged event for month navigation tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,37 @@ This mode is ideal for:
 </owl-date-time>
 ```
 
+## Month Change Event
+
+The date-time picker provides a `monthChanged` event that fires whenever the current viewing month changes.
+
+### Usage
+
+```typescript
+export class MyComponent {
+    currentMonth = new Date();
+
+    onMonthChanged(month: Date): void {
+        this.currentMonth = month;
+        console.log('Month changed to:', month.toLocaleDateString('en-US', { 
+            year: 'numeric', 
+            month: 'long' 
+        }));
+        
+        // Load data for the new month
+        this.loadMonthData(month);
+    }
+}
+```
+
+```html
+<owl-date-time
+    [startAt]="selectedDate"
+    (monthChanged)="onMonthChanged($event)"
+    (dateSelected)="onDateSelected($event)">
+</owl-date-time>
+```
+
 ## Animation
 
 This picker uses angular animations to improve the user experience,
@@ -197,6 +228,7 @@ There are two pre-made modules, users need to import one of them or build your o
 | `afterPickerClosed` | null      | Callback to invoke when the picker is closed.                                                   |
 | `yearSelected`      | T         | Callback to invoke when the year is selected.This doesn't imply a change on the selected date.  |
 | `monthSelected`     | T         | Callback to invoke when the month is selected.This doesn't imply a change on the selected date. |
+| `monthChanged`      | T         | Callback to invoke when the current viewing month changes (navigation, month selection).        |
 | `dateClicked`       | T         | Callback when the selected data changes.                                                        |
 | `selectedChanged`   | T         | Callback when the currently selected data changes.                                              |
 | `userSelection`     | null      | Callback when any date is selected.                                                             |

--- a/projects/picker/src/lib/date-time/calendar.component.ts
+++ b/projects/picker/src/lib/date-time/calendar.component.ts
@@ -291,6 +291,12 @@ export class OwlCalendarComponent<T>
     @Output()
     readonly monthSelected = new EventEmitter<T>();
 
+    /**
+     * Emits when the current viewing month changes (navigation, month selection)
+     * */
+    @Output()
+    readonly monthChanged = new EventEmitter<T>();
+
     private _currentView: DateViewType;
 
     private intlChangesSub = Subscription.EMPTY;
@@ -362,6 +368,9 @@ export class OwlCalendarComponent<T>
             : this.dateTimeAdapter.addCalendarYears(this.pickerMoment, -1);
 
         this.pickerMomentChange.emit(this.pickerMoment);
+        if (this.isMonthView) {
+            this.monthChanged.emit(this.pickerMoment);
+        }
     }
 
     /**
@@ -373,6 +382,9 @@ export class OwlCalendarComponent<T>
             : this.dateTimeAdapter.addCalendarYears(this.pickerMoment, 1);
 
         this.pickerMomentChange.emit(this.pickerMoment);
+        if (this.isMonthView) {
+            this.monthChanged.emit(this.pickerMoment);
+        }
     }
 
     public dateSelected(date: T): void {
@@ -411,12 +423,20 @@ export class OwlCalendarComponent<T>
      * Change the pickerMoment value
      */
     public handlePickerMomentChange(date: T): void {
+        const previousMonth = this.pickerMoment;
         this.pickerMoment = this.dateTimeAdapter.clampDate(
             date,
             this.minDate,
             this.maxDate
         );
         this.pickerMomentChange.emit(this.pickerMoment);
+        
+        // Emit monthChanged if the month actually changed and we're in month view
+        if (this.isMonthView && previousMonth && 
+            (this.dateTimeAdapter.getYear(previousMonth) !== this.dateTimeAdapter.getYear(this.pickerMoment) ||
+             this.dateTimeAdapter.getMonth(previousMonth) !== this.dateTimeAdapter.getMonth(this.pickerMoment))) {
+            this.monthChanged.emit(this.pickerMoment);
+        }
         return;
     }
 
@@ -464,6 +484,8 @@ export class OwlCalendarComponent<T>
 
     public selectMonthInYearView(normalizedMonth: T): void {
         this.monthSelected.emit(normalizedMonth);
+        // Also emit monthChanged when selecting a month from year view
+        this.monthChanged.emit(normalizedMonth);
     }
 
     /**

--- a/projects/picker/src/lib/date-time/date-time-inline.component.ts
+++ b/projects/picker/src/lib/date-time/date-time-inline.component.ts
@@ -238,6 +238,12 @@ export class OwlDateTimeInlineComponent<T> extends OwlDateTime<T>
     monthSelected = new EventEmitter<T>();
 
     /**
+     * Emits when the current viewing month changes (navigation, month selection)
+     * */
+    @Output()
+    monthChanged = new EventEmitter<T>();
+
+    /**
      * Emits selected date
      * */
     @Output()

--- a/projects/picker/src/lib/date-time/date-time-picker-container.component.html
+++ b/projects/picker/src/lib/date-time/date-time-picker-container.component.html
@@ -22,6 +22,7 @@
             [hideOtherMonths]="picker.hideOtherMonths"
             (yearSelected)="picker.selectYear($event)"
             (monthSelected)="picker.selectMonth($event)"
+            (monthChanged)="picker.monthChanged.emit($event)"
             (dateClicked)="picker.selectDate($event)"
             (selectedChange)="dateSelected($event)"
         ></owl-date-time-calendar>

--- a/projects/picker/src/lib/date-time/date-time-picker.component.ts
+++ b/projects/picker/src/lib/date-time/date-time-picker.component.ts
@@ -253,6 +253,12 @@ export class OwlDateTimeComponent<T> extends OwlDateTime<T>
     monthSelected = new EventEmitter<T>();
 
     /**
+     * Emits when the current viewing month changes (navigation, month selection)
+     * */
+    @Output()
+    monthChanged = new EventEmitter<T>();
+
+    /**
      * Emits selected date
      * */
     @Output()

--- a/projects/picker/src/lib/date-time/date-time.class.ts
+++ b/projects/picker/src/lib/date-time/date-time.class.ts
@@ -200,6 +200,8 @@ export abstract class OwlDateTime<T> {
 
     abstract monthSelected: EventEmitter<T>;
 
+    abstract monthChanged: EventEmitter<T>;
+
     abstract dateSelected: EventEmitter<T>;
 
     abstract selectYear(normalizedYear: T): void;

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -20,6 +20,11 @@
     [class.active]="currentTab() === 'view-only-agenda'">
     View Only Agenda:
   </button>
+  <button
+    (click)="currentTab.set('month-change-demo')"
+    [class.active]="currentTab() === 'month-change-demo'">
+    Month Change Event:
+  </button>
 </div>
 
 <main>
@@ -98,6 +103,29 @@
             (afterPickerClosed)="selectedTrigger($event)"
             (dateSelected)="selectedTrigger($event)">
         </owl-date-time>
+    }
+    @case ('month-change-demo') {
+      <label for="monthchangedemo">
+        Month Change Event Demo (check console for month change events):
+      </label>
+      <div style="margin-bottom: 10px; padding: 10px; background-color: #f0f0f0; border-radius: 4px;">
+        <strong>Current Month:</strong> {{ currentMonth | date:'MMMM yyyy' }}
+      </div>
+      <input
+        [(ngModel)]="selectedDateWithAgenda"
+        [selectMode]="'single'"
+        [owlDateTimeTrigger]="month_change_demo_component"
+        [owlDateTime]="month_change_demo_component"
+        style="width: 100%; color: cornflowerblue"
+        id="monthchangedemo">
+      <owl-date-time
+        #month_change_demo_component
+        [startAt]="selectedDateWithAgenda"
+        [agendas]="agendas"
+        (afterPickerClosed)="selectedTrigger($event)"
+        (dateSelected)="selectedTrigger($event)"
+        (monthChanged)="onMonthChanged($event)">
+      </owl-date-time>
     }
   }
 </main>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+import { DatePipe } from '@angular/common';
 import { OwlDateTimeModule, OwlNativeDateTimeModule } from '../../projects/picker/src/public_api';
 import { CalendarAgenda } from '../../projects/picker/src/lib/date-time/calendar-agenda.class';
 
@@ -14,6 +15,7 @@ const ONE_DAY = 24 * 60 * 60 * 1000;
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     FormsModule,
+    DatePipe,
     OwlDateTimeModule,
     OwlNativeDateTimeModule
   ]
@@ -27,6 +29,8 @@ export class AppComponent {
   ];
 
   protected selectedDateWithAgenda = new Date();
+
+  protected currentMonth = new Date();
 
   protected agendas: CalendarAgenda[] = [];
 
@@ -66,5 +70,13 @@ export class AppComponent {
 
   protected selectedTrigger(date: Date): void {
     console.log(date);
+  }
+
+  protected onMonthChanged(month: Date): void {
+    this.currentMonth = month;
+    console.log('Month changed to:', month.toLocaleDateString('en-US', { 
+      year: 'numeric', 
+      month: 'long' 
+    }));
   }
 }


### PR DESCRIPTION
- Add monthChanged output event across all picker components
- Emit when month changes via buttons, year selection, or keyboard
- Update demo and documentation