### PR TITLE
CT-9528 add refreshAgendas() method for async agenda updates

### DIFF
--- a/projects/picker/src/lib/date-time/calendar-month-view.component.ts
+++ b/projects/picker/src/lib/date-time/calendar-month-view.component.ts
@@ -703,4 +703,16 @@ export class OwlMonthViewComponent<T>
     private focusActiveCell() {
         this.calendarBodyElm.focusActiveCell();
     }
+
+    /**
+     * Refresh agendas and trigger change detection
+     * Use this method when updating agendas asynchronously (e.g., from server)
+     * This method will regenerate the calendar with the current agendas data
+     */
+    public refreshAgendas(): void {
+        if (this.initiated) {
+            this.generateCalendar();
+            this.cdRef.markForCheck();
+        }
+    }
 }

--- a/projects/picker/src/lib/date-time/calendar.component.ts
+++ b/projects/picker/src/lib/date-time/calendar.component.ts
@@ -522,4 +522,12 @@ export class OwlCalendarComponent<T>
             ? obj
             : null;
     }
+
+    /**
+     * Refresh agendas and trigger change detection
+     * Use this method when updating agendas asynchronously (e.g., from server)
+     */
+    public refreshAgendas(): void {
+        this.cdRef.markForCheck();
+    }
 }

--- a/projects/picker/src/lib/date-time/date-time-inline.component.ts
+++ b/projects/picker/src/lib/date-time/date-time-inline.component.ts
@@ -368,4 +368,14 @@ export class OwlDateTimeInlineComponent<T> extends OwlDateTime<T>
      public selectDate(normalizedDate: T): void {
         this.dateSelected.emit(normalizedDate);
     }
+
+    /**
+     * Refresh agendas and trigger change detection
+     * Use this method when updating agendas asynchronously (e.g., from server)
+     */
+    public refreshAgendas(): void {
+        if (this.container) {
+            this.container.refreshAgendas();
+        }
+    }
 }

--- a/projects/picker/src/lib/date-time/date-time-picker-container.component.ts
+++ b/projects/picker/src/lib/date-time/date-time-picker-container.component.ts
@@ -586,4 +586,19 @@ export class OwlDateTimeContainerComponent<T>
 
         this.cdRef.markForCheck();
     }
+
+    /**
+     * Refresh agendas and trigger change detection
+     * Use this method when updating agendas asynchronously (e.g., from server)
+     */
+    public refreshAgendas(): void {
+        if (this.calendar) {
+            this.calendar.refreshAgendas();
+        }
+        // Update agendas for selected date if there's a selected date
+        if (this.picker.selected) {
+            this.filterAgendasForSelectedDate(this.picker.selected);
+        }
+        this.cdRef.markForCheck();
+    }
 }

--- a/projects/picker/src/lib/date-time/date-time-picker.component.ts
+++ b/projects/picker/src/lib/date-time/date-time-picker.component.ts
@@ -737,8 +737,18 @@ export class OwlDateTimeComponent<T> extends OwlDateTime<T>
                     originY: 'top',
                     overlayX: 'start',
                     overlayY: 'top',
-                    offsetY: -352
-                }
-            ]);
+                offsetY: -352
+            }
+        ]);
+    }
+
+    /**
+     * Refresh agendas and trigger change detection
+     * Use this method when updating agendas asynchronously (e.g., from server)
+     */
+    public refreshAgendas(): void {
+        if (this.pickerContainer) {
+            this.pickerContainer.refreshAgendas();
+        }
     }
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, signal, ViewChild } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { DatePipe } from '@angular/common';
 import { OwlDateTimeModule, OwlNativeDateTimeModule } from '../../projects/picker/src/public_api';
@@ -34,7 +34,9 @@ export class AppComponent {
 
   protected agendas: CalendarAgenda[] = [];
 
-  constructor() {
+  @ViewChild('month_change_demo_component') monthChangeDemoComponent: any;
+
+  constructor(private cdr: ChangeDetectorRef) {
     // Initialize with current month's agendas
     this.generateAgendasForMonth(new Date());
   }
@@ -67,16 +69,29 @@ export class AppComponent {
     // Generate different agenda patterns for each month
     const monthPatterns = this.getMonthPatterns(monthIndex);
     
-    // Generate agendas for random days in the month
-    const agendaDays = this.getRandomDays(daysInMonth, monthPatterns.agendaCount);
-    
-    agendaDays.forEach(day => {
-      const dayDate = new Date(year, monthIndex, day);
-      const agendasForDay = this.generateAgendasForDay(dayDate, monthPatterns);
-      this.agendas.push(...agendasForDay);
-    });
-    
-    console.log(`Generated ${this.agendas.length} agendas for ${month.toLocaleDateString('en-US', { month: 'long', year: 'numeric' })}`);
+    // Simulate async data fetching (like from server)
+    this.agendas = [];
+    setTimeout(() => {
+      const newAgendas: CalendarAgenda[] = [];
+      
+      // Generate agendas for random days in the month
+      const agendaDays = this.getRandomDays(daysInMonth, monthPatterns.agendaCount);
+      
+      agendaDays.forEach(day => {
+        const dayDate = new Date(year, monthIndex, day);
+        const agendasForDay = this.generateAgendasForDay(dayDate, monthPatterns);
+        newAgendas.push(...agendasForDay);
+      });
+      
+      console.log(`Generated ${newAgendas.length} agendas for ${month.toLocaleDateString('en-US', { month: 'long', year: 'numeric' })}`);
+
+      // Update agendas and refresh the calendar
+      this.agendas = [...newAgendas];
+      if (this.monthChangeDemoComponent) {
+        this.monthChangeDemoComponent.refreshAgendas();
+      }
+      this.cdr.markForCheck();
+    }, 500); // 500ms delay to simulate server response
   }
 
   private getMonthPatterns(monthIndex: number): { agendaCount: number; timeSlots: number[]; duration: number } {


### PR DESCRIPTION
- Add refreshAgendas() to all picker components for manual refresh
- Enable proper handling of async agenda data loading
- Update demo to demonstrate async data fetching with 500ms delay